### PR TITLE
🏋🏻‍♂️add react-navigation v5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"react-test-renderer": "^16.12.0"
 	},
 	"dependencies": {
-		"expo-navigation-core": "^0.1.0",
+		"expo-navigation-core": "^0.2.0",
 		"lodash": "^4.17.15"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"test": "expo-module test",
 		"prepare": "expo-module prepare",
 		"prepublishOnly": "expo-module prepublishOnly",
-		"expo-module": "expo-module"
+		"expo-module": "expo-module",
+		"upload": "yarn publish --v5"
 	},
 	"files": [
 		"build"
@@ -44,7 +45,7 @@
 		"react-test-renderer": "^16.12.0"
 	},
 	"dependencies": {
-		"expo-navigation-core": "0.0.10",
+		"expo-navigation-core": "^0.1.0",
 		"lodash": "^4.17.15"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "expo-gatsby-navigation",
-	"version": "0.0.8",
+	"version": "0.1.0",
 	"description": "Make Gatsby and React Navigation play nicely together with an Expo/React Native Web app.",
 	"sideEffects": true,
 	"main": "build/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,6 +1232,24 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-navigation/core@^5.0.0-alpha.37":
+  version "5.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.0.0-alpha.37.tgz#0e91dc2f1d46d646a5d63f882dc3c18a9e74a2cf"
+  integrity sha512-lTk7yx9jqzK3+yRxX+yz8v+1uw9aOaX1LfQFPpgwyJUAjQdZU9qqigSd/qZHtaOSg5XCOacjO+G4Qk9/hNp+Ag==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+    query-string "^6.9.0"
+    react-is "^16.12.0"
+    shortid "^2.2.15"
+    use-subscription "^1.3.0"
+
+"@react-navigation/native@^5.0.0-alpha.29":
+  version "5.0.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.0.0-alpha.29.tgz#0b286aaf8d15868766513f58b2b1fc45a1559d8b"
+  integrity sha512-Axd9stTTc4MVNwXvU356UNi+svEmOhB3f98YD68IJpkck6+wT1qMN4kgP2tBaA4FFON8VtxQnc2Sz9+FroXnfg==
+  dependencies:
+    "@react-navigation/core" "^5.0.0-alpha.37"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -4616,6 +4634,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escodegen@^1.9.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.1.tgz#08770602a74ac34c7a90ca9229e7d51e379abc76"
@@ -5050,13 +5073,13 @@ expo-module-scripts@^1.1.1:
     ts-jest "~24.0.2"
     typescript "^3.4.3"
 
-expo-navigation-core@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/expo-navigation-core/-/expo-navigation-core-0.0.10.tgz#ba71b8db76252dedc004ff1d724519556f9c50ce"
-  integrity sha512-nmWU9MkHHfl1dN33iU/Mx97xzh/e/lGeV4tYIZF30f1t+5enp4QVPmKDrqy9OSL35sYh5dWHWCAq4TMBxfCYhQ==
+expo-navigation-core@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/expo-navigation-core/-/expo-navigation-core-0.1.0.tgz#4cfacd127cc18919f5c7eca3347bc95aac97a0d2"
+  integrity sha512-UWPmV67FUuo4LBT+XIER1gyt8UmUQCQGaAXZkKe6PnpnrStH3hDeZANPeglL9weO9iHppFYXSKEU8gKTaB/zIw==
   dependencies:
+    "@react-navigation/native" "^5.0.0-alpha.29"
     lodash "^4.17.15"
-    react-navigation-hooks "^1.1.0"
 
 express-graphql@^0.9.0:
   version "0.9.0"
@@ -8979,6 +9002,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.0:
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.10.tgz#66fb5ac664ee2d3017f451b9f0d26cfec3c034b5"
+  integrity sha512-ZPUHBAwrQ+BSwVV2Xh6hBOEStTzAf8LgohOY0kk22lDiDdI32582KjVPYCqgqj7834hTunGzwZOB4me9T6ZcnA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -10523,6 +10551,15 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.9.0:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.10.1.tgz#30b3505f6fca741d5ae541964d1b3ae9dc2a0de8"
+  integrity sha512-SHTUV6gDlgMXg/AQUuLpTiBtW/etZ9JT6k6RCtCyqADquApLX0Aq5oK/s5UeTUAWBG50IExjIr587GqfXRfM4A==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10738,11 +10775,6 @@ react-native-web@^0.11.7:
     scheduler "0.15.0"
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
-
-react-navigation-hooks@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-navigation-hooks/-/react-navigation-hooks-1.1.0.tgz#337c41a50ebc7b9030bb9d9333cd4fd6e1f86b68"
-  integrity sha512-ZY/aiYJ88KXaOo8iOa4171O/0x6ztGhUPd2OYzdaJhLT/tP64zi5HB/RZFImuKhaBTODXjoSpFaOTA5xpePG4g==
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -11599,6 +11631,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shortid@^2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
+
 sift@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/sift/-/sift-5.1.0.tgz#1bbf2dfb0eb71e56c4cc7fb567fbd1351b65015e"
@@ -11892,6 +11931,11 @@ spdy@^4.0.1:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -12012,6 +12056,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -12776,6 +12825,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-subscription@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.3.0.tgz#3df13a798e826c8d462899423293289a3362e4e6"
+  integrity sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==
+  dependencies:
+    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5073,10 +5073,10 @@ expo-module-scripts@^1.1.1:
     ts-jest "~24.0.2"
     typescript "^3.4.3"
 
-expo-navigation-core@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/expo-navigation-core/-/expo-navigation-core-0.1.0.tgz#4cfacd127cc18919f5c7eca3347bc95aac97a0d2"
-  integrity sha512-UWPmV67FUuo4LBT+XIER1gyt8UmUQCQGaAXZkKe6PnpnrStH3hDeZANPeglL9weO9iHppFYXSKEU8gKTaB/zIw==
+expo-navigation-core@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/expo-navigation-core/-/expo-navigation-core-0.2.0.tgz#642cde445ef4aca2cbd48f946b1539173703e773"
+  integrity sha512-iuU1qInD8TUb/NMGToPZ5jJOrhj0eFznvJd7lTG0Bvp1MMsa7T8zpV/+PV0D3U9BJZK5zBe7FMaCIRlYxfTZpw==
   dependencies:
     "@react-navigation/native" "^5.0.0-alpha.29"
     lodash "^4.17.15"


### PR DESCRIPTION
Close #2 and #3 

**This library's API has not changed,** but react navigation v5 is now supported with this PR.

To support `v5`, be sure to add the `@v5` flag when you install:

```sh
yarn add expo-gatsby-navigation@v5
```

This now works with React Navigation `v5` without any API changes. Down the road, it might be smart to change the API to match that of `v5`, but the changes are minor.

## **Code changes**

- `navigation` function uses a `name` instead of `routeName` and has an optional `key` field.
- `getParam` is deprecated in `v5` in favor of `useRoute`'s `params` field. The `useRoute` hook is thus included in the `useRouting` hook this library already offered. However, this library still relies on the `getParam` function.
- Add the `params` field to be returned from `useRouting`.
## **Breaking changes**

- none (hopefully 😇)
